### PR TITLE
Fix for clipboard error when copying keys

### DIFF
--- a/TxEditor/ViewModels/MainViewModel.cs
+++ b/TxEditor/ViewModels/MainViewModel.cs
@@ -1937,7 +1937,7 @@ namespace Unclassified.TxEditor.ViewModels
 			string str = selectedTextKeys
 				.Select(tk => tk.TextKey)
 				.Aggregate((a, b) => a + Environment.NewLine + b);
-			Clipboard.SetText(str);
+			Clipboard.SetDataObject(str);
 			StatusText = Tx.T("statusbar.text key copied");
 		}
 


### PR DESCRIPTION
In some cases the program got an error when copying keys to the clipboard.
This small change fixes the problem.