### PR TITLE
Added support for templating paramaters in Wpf/XAML

### DIFF
--- a/TxLib/TxXaml.cs
+++ b/TxLib/TxXaml.cs
@@ -13,7 +13,9 @@
 // library. If not, see <http://www.gnu.org/licenses/>.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 using System.Windows;
 using System.Windows.Data;
 using System.Windows.Markup;
@@ -71,6 +73,117 @@ namespace Unclassified.TxLib
 			Count = -1;
 		}
 
+		/// <summary>
+		/// Initialises a new instance of the TExtension class.
+		/// </summary>
+		/// <param name="key">Text key to translate.</param>
+		/// <param name = "placeholderKey1" > The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder1">The value binding to replace the placeholder when templating.</param>
+		public TExtension(string key, string placeholderKey1, Binding placeholder1)
+        {
+			Key = key;
+			Count = -1;
+			PlaceholderKey1 = placeholderKey1;
+			PlaceholderBinding1 = placeholder1;
+        }
+
+		/// <summary>
+		/// Initialises a new instance of the TExtension class.
+		/// </summary>
+		/// <param name="key">Text key to translate.</param>
+		/// <param name="count">Count value to consider when selecting the text value.</param>
+		/// <param name="placeholderKey1">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder1">The value binding to replace the placeholder when templating.</param>
+		public TExtension(string key, int count, string placeholderKey1, Binding placeholder1)
+        {
+			Key = key;
+			Count = count;
+			PlaceholderKey1 = placeholderKey1;
+			PlaceholderBinding1 = placeholder1;
+		}
+
+		/// <summary>
+		/// Initialises a new instance of the TExtension class.
+		/// </summary>
+		/// <param name="key">Text key to translate.</param>
+		/// <param name="placeholderKey1">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder1">The value binding to replace the placeholder when templating.</param>
+		/// <param name="placeholderKey2">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder2">The value binding to replace the placeholder when templating.</param>
+		public TExtension(string key, string placeholderKey1, Binding placeholder1, string placeholderKey2, Binding placeholder2)
+		{
+			Key = key;
+			Count = -1;
+			PlaceholderKey1 = placeholderKey1;
+			PlaceholderBinding1 = placeholder1;
+			PlaceholderKey2 = placeholderKey2;
+			PlaceholderBinding2 = placeholder2;
+		}
+
+		/// <summary>
+		/// Initialises a new instance of the TExtension class.
+		/// </summary>
+		/// <param name="key">Text key to translate.</param>
+		/// <param name="count">Count value to consider when selecting the text value.</param>
+		/// <param name="placeholderKey1">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder1">The value binding to replace the placeholder when templating.</param>
+		/// <param name="placeholderKey2">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder2">The value binding to replace the placeholder when templating.</param>
+		public TExtension(string key, int count, string placeholderKey1, Binding placeholder1, string placeholderKey2, Binding placeholder2)
+		{
+			Key = key;
+			Count = count;
+			PlaceholderKey1 = placeholderKey1;
+			PlaceholderBinding1 = placeholder1;
+			PlaceholderKey2 = placeholderKey2;
+			PlaceholderBinding2 = placeholder2;
+		}
+
+		/// <summary>
+		/// Initialises a new instance of the TExtension class.
+		/// </summary>
+		/// <param name="key">Text key to translate.</param>
+		/// <param name="placeholderKey1">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder1">The value binding to replace the placeholder when templating.</param>
+		/// <param name="placeholderKey2">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder2">The value binding to replace the placeholder when templating.</param>
+		/// <param name="placeholderKey3">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder3">The value binding to replace the placeholder when templating.</param>
+		public TExtension(string key, string placeholderKey1, Binding placeholder1, string placeholderKey2, Binding placeholder2, string placeholderKey3, Binding placeholder3)
+		{
+			Key = key;
+			Count = -1;
+			PlaceholderKey1 = placeholderKey1;
+			PlaceholderBinding1 = placeholder1;
+			PlaceholderKey2 = placeholderKey2;
+			PlaceholderBinding2 = placeholder2;
+			PlaceholderKey3 = placeholderKey3;
+			PlaceholderBinding3 = placeholder3;
+		}
+
+		/// <summary>
+		/// Initialises a new instance of the TExtension class.
+		/// </summary>
+		/// <param name="key">Text key to translate.</param>
+		/// <param name="count">Count value to consider when selecting the text value.</param>
+		/// <param name="placeholderKey1">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder1">The value binding to replace the placeholder when templating.</param>
+		/// <param name="placeholderKey2">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder2">The value binding to replace the placeholder when templating.</param>
+		/// <param name="placeholderKey3">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder3">The value binding to replace the placeholder when templating.</param>
+		public TExtension(string key, int count, string placeholderKey1, Binding placeholder1, string placeholderKey2, Binding placeholder2, string placeholderKey3, Binding placeholder3)
+		{
+			Key = key;
+			Count = count;
+			PlaceholderKey1 = placeholderKey1;
+			PlaceholderBinding1 = placeholder1;
+			PlaceholderKey2 = placeholderKey2;
+			PlaceholderBinding2 = placeholder2;
+			PlaceholderKey3 = placeholderKey3;
+			PlaceholderBinding3 = placeholder3;
+		}
+
 		#endregion Constructors
 
 		#region Properties
@@ -91,6 +204,36 @@ namespace Unclassified.TxLib
 		public BindingBase CountBinding { get; set; }
 
 		/// <summary>
+		/// Gets or sets the name of placeholder one.
+		/// </summary>
+		public string PlaceholderKey1 { get; set; }
+
+		/// <summary>
+		/// Gets or sets the binding that provides the placeholder one value to use when templating the translation.
+		/// </summary>
+		public BindingBase PlaceholderBinding1 { get; set; }
+
+		/// <summary>
+		/// Gets or sets the name of placeholder two.
+		/// </summary>
+		public string PlaceholderKey2 { get; set; }
+
+		/// <summary>
+		/// Gets or sets the binding that provides the placeholder two value to use when templating the translation.
+		/// </summary>
+		public BindingBase PlaceholderBinding2 { get; set; }
+
+		/// <summary>
+		/// Gets or sets the name of placeholder three.
+		/// </summary>
+		public string PlaceholderKey3 { get; set; }
+
+		/// <summary>
+		/// Gets or sets the binding that provides the placeholder three value to use when templating the translation.
+		/// </summary>
+		public BindingBase PlaceholderBinding3 { get; set; }
+
+		/// <summary>
 		/// Gets or sets the default text to display at design time.
 		/// </summary>
 		public string Default { get; set; }
@@ -103,10 +246,28 @@ namespace Unclassified.TxLib
 		/// Provides the T method in specialised classes.
 		/// </summary>
 		/// <returns></returns>
-		protected virtual Func<string, int, string> GetTFunc()
+		protected virtual Func<string, int, string> GetTFuncCount()
 		{
 			return Tx.T;
 		}
+
+		/// <summary>
+		/// Provides the T method in specialised classes.
+		/// </summary>
+		/// <returns></returns>
+		protected virtual Func<string, string[], string> GetTFuncPlaceholders()
+        {
+			return Tx.T;
+        }
+
+		/// <summary>
+		/// Provides the T method in specialised classes.
+		/// </summary>
+		/// <returns></returns>
+		protected virtual Func<string, int, string[], string> GetTFuncCountAndPlaceholders()
+        {
+			return Tx.T;
+        }
 
 		#endregion Converter action
 
@@ -127,28 +288,84 @@ namespace Unclassified.TxLib
 			binding.Source = DictionaryWatcher.Instance;
 			binding.Mode = BindingMode.OneWay;
 
-			if (CountBinding != null)
-			{
-				// A CountBinding has been set, so multiple bindings need to be combined.
+			var bindCount = CountBinding != null;
+			var bindPlaceholder1 = PlaceholderBinding1 != null;
+			var bindPlaceholder2 = bindPlaceholder1 && PlaceholderBinding2 != null;
+			var bindPlaceholder3 = bindPlaceholder2 && PlaceholderBinding3 != null;
+			var bindPlaceholders = bindPlaceholder1;
+
+			if (bindPlaceholder1 && string.IsNullOrEmpty(PlaceholderKey1))
+				throw new ArgumentException("Placeholder key 1 is not specified");
+
+			if (bindPlaceholder2 && string.IsNullOrEmpty(PlaceholderKey2))
+				throw new ArgumentException("Placeholder key 2 is not specified");
+
+			if (bindPlaceholder3 && string.IsNullOrEmpty(PlaceholderKey3))
+				throw new ArgumentException("Placeholder key 3 is not specified");
+
+			if (bindCount || bindPlaceholders)
+            {
+				// Optional bindings have been set, so multiple bindings need to be combined.
 				MultiBinding multiBinding = new MultiBinding();
 				multiBinding.Mode = BindingMode.TwoWay;
 
 				// Add the dummy binding as well as the binding for the count value.
 				multiBinding.Bindings.Add(binding);
-				multiBinding.Bindings.Add(CountBinding);
+				if (bindCount) multiBinding.Bindings.Add(CountBinding);
+				if (bindPlaceholder1) multiBinding.Bindings.Add(PlaceholderBinding1);
+				if (bindPlaceholder2) multiBinding.Bindings.Add(PlaceholderBinding2);
+				if (bindPlaceholder3) multiBinding.Bindings.Add(PlaceholderBinding3);
 
 				// The converter will invoke the actual translation of the key and additional data.
-				multiBinding.Converter = new TConverter(GetTFunc(), Key, Default);
-				return multiBinding.ProvideValue(serviceProvider);
+				if (bindCount && !bindPlaceholders)
+                {
+					multiBinding.Converter = new TConverter(GetTFuncCount(), Key, Default);
+					return multiBinding.ProvideValue(serviceProvider);
+				}
+				else if (!bindCount && bindPlaceholders)
+                {
+					var placeholder_keys = new string[] { PlaceholderKey1, PlaceholderKey2, PlaceholderKey3 }.Where(s => s != null).ToArray();
+					multiBinding.Converter = new TConverter(GetTFuncPlaceholders(), Key, placeholder_keys, Default);
+					return multiBinding.ProvideValue(serviceProvider);
+                }
+				else
+                {
+					var placeholder_keys = new string[] { PlaceholderKey1, PlaceholderKey2, PlaceholderKey3 }.Where(s => s != null).ToArray();
+					multiBinding.Converter = new TConverter(GetTFuncCountAndPlaceholders(), Key, Count, placeholder_keys, Default);
+					return multiBinding.ProvideValue(serviceProvider);
+				}
 			}
-			else
-			{
-				// No CountBinding, so a simple binding will do.
+            else
+            {
+				// No optional binding, so a simple binding will do.
 
 				// The converter will invoke the actual translation of the key and additional data.
-				binding.Converter = new TConverter(GetTFunc(), Key, Count, Default);
+				binding.Converter = new TConverter(GetTFuncCount(), Key, Count, Default);
 				return binding.ProvideValue(serviceProvider);
 			}
+
+			//if (CountBinding != null)
+			//{
+			//	// A CountBinding has been set, so multiple bindings need to be combined.
+			//	MultiBinding multiBinding = new MultiBinding();
+			//	multiBinding.Mode = BindingMode.TwoWay;
+
+			//	// Add the dummy binding as well as the binding for the count value.
+			//	multiBinding.Bindings.Add(binding);
+			//	multiBinding.Bindings.Add(CountBinding);
+
+			//	// The converter will invoke the actual translation of the key and additional data.
+			//	multiBinding.Converter = new TConverter(GetTFuncCount(), Key, Default);
+			//	return multiBinding.ProvideValue(serviceProvider);
+			//}
+			//else
+			//{
+			//	// No CountBinding, so a simple binding will do.
+
+			//	// The converter will invoke the actual translation of the key and additional data.
+			//	binding.Converter = new TConverter(GetTFuncCount(), Key, Count, Default);
+			//	return binding.ProvideValue(serviceProvider);
+			//}
 		}
 
 		#endregion MarkupExtension overrides
@@ -198,6 +415,87 @@ namespace Unclassified.TxLib
 		{
 		}
 
+		/// <summary>
+		/// Initialises a new instance of the UTExtension class.
+		/// </summary>
+		/// <param name="key">Text key to translate.</param>
+		/// <param name="placeholderKey1">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder1">The value binding to replace the placeholder when templating.</param>
+		public UTExtension(string key, string placeholderKey1, Binding placeholder1)
+			: base(key, placeholderKey1, placeholder1)
+        {
+        }
+
+		/// <summary>
+		/// Initialises a new instance of the UTExtension class.
+		/// </summary>
+		/// <param name="key">Text key to translate.</param>
+		/// <param name="count"> Count value to consider when selecting the text value.</param>
+		/// <param name="placeholderKey1">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder1">The value binding to replace the placeholder when templating.</param>
+		public UTExtension(string key, int count, string placeholderKey1, Binding placeholder1)
+			: base(key, count, placeholderKey1, placeholder1)
+		{
+		}
+
+		/// <summary>
+		/// Initialises a new instance of the UTExtension class.
+		/// </summary>
+		/// <param name="key">Text key to translate.</param>
+		/// <param name="placeholderKey1">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder1">The value binding to replace the placeholder when templating.</param>
+		/// <param name="placeholderKey2">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder2">The value binding to replace the placeholder when templating.</param>
+		public UTExtension(string key, string placeholderKey1, Binding placeholder1, string placeholderKey2, Binding placeholder2)
+			: base(key, placeholderKey1, placeholder1, placeholderKey2, placeholder2)
+		{
+		}
+
+		/// <summary>
+		/// Initialises a new instance of the UTExtension class.
+		/// </summary>
+		/// <param name="key">Text key to translate.</param>
+		/// <param name="count" > Count value to consider when selecting the text value.</param>
+		/// <param name="placeholderKey1">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder1">The value binding to replace the placeholder when templating.</param>
+		/// <param name="placeholderKey2">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder2">The value binding to replace the placeholder when templating.</param>
+		public UTExtension(string key, int count, string placeholderKey1, Binding placeholder1, string placeholderKey2, Binding placeholder2)
+			: base(key, count, placeholderKey1, placeholder1, placeholderKey2, placeholder2)
+		{
+		}
+
+		/// <summary>
+		/// Initialises a new instance of the UTExtension class.
+		/// </summary>
+		/// <param name="key">Text key to translate.</param>
+		/// <param name="placeholderKey1">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder1">The value binding to replace the placeholder when templating.</param>
+		/// <param name="placeholderKey2">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder2">The value binding to replace the placeholder when templating.</param>
+		/// <param name="placeholderKey3">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder3">The value binding to replace the placeholder when templating.</param>
+		public UTExtension(string key, string placeholderKey1, Binding placeholder1, string placeholderKey2, Binding placeholder2, string placeholderKey3, Binding placeholder3)
+			: base(key, placeholderKey1, placeholder1, placeholderKey2, placeholder2, placeholderKey3, placeholder3)
+		{
+		}
+
+		/// <summary>
+		/// Initialises a new instance of the UTExtension class.
+		/// </summary>
+		/// <param name="key">Text key to translate.</param>
+		/// <param name="count" > Count value to consider when selecting the text value.</param>
+		/// <param name="placeholderKey1">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder1">The value binding to replace the placeholder when templating.</param>
+		/// <param name="placeholderKey2">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder2">The value binding to replace the placeholder when templating.</param>
+		/// <param name="placeholderKey3">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder3">The value binding to replace the placeholder when templating.</param>
+		public UTExtension(string key, int count, string placeholderKey1, Binding placeholder1, string placeholderKey2, Binding placeholder2, string placeholderKey3, Binding placeholder3)
+			: base(key, count, placeholderKey1, placeholder1, placeholderKey2, placeholder2, placeholderKey3, placeholder3)
+		{
+		}
+
 		#endregion Constructors
 
 		#region Converter action
@@ -206,7 +504,25 @@ namespace Unclassified.TxLib
 		/// Provides the T method in specialised classes.
 		/// </summary>
 		/// <returns></returns>
-		protected override Func<string, int, string> GetTFunc()
+		protected override Func<string, int, string> GetTFuncCount()
+		{
+			return Tx.UT;
+		}
+
+		/// <summary>
+		/// Provides the T method in specialised classes.
+		/// </summary>
+		/// <returns></returns>
+		protected override Func<string, string[], string> GetTFuncPlaceholders()
+		{
+			return Tx.UT;
+		}
+
+		/// <summary>
+		/// Provides the T method in specialised classes.
+		/// </summary>
+		/// <returns></returns>
+		protected override Func<string, int, string[], string> GetTFuncCountAndPlaceholders()
 		{
 			return Tx.UT;
 		}
@@ -258,6 +574,87 @@ namespace Unclassified.TxLib
 		{
 		}
 
+		/// <summary>
+		/// Initialises a new instance of the TCExtension class.
+		/// </summary>
+		/// <param name="key">Text key to translate.</param>
+		/// <param name="placeholderKey1">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder1">The value binding to replace the placeholder when templating.</param>
+		public TCExtension(string key, string placeholderKey1, Binding placeholder1)
+			: base(key, placeholderKey1, placeholder1)
+        {
+        }
+
+		/// <summary>
+		/// Initialises a new instance of the TCExtension class.
+		/// </summary>
+		/// <param name="key">Text key to translate.</param>
+		/// <param name="count">Count value to consider when selecting the text value.</param>
+		/// <param name="placeholderKey1">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder1">The value binding to replace the placeholder when templating.</param>
+		public TCExtension(string key, int count, string placeholderKey1, Binding placeholder1)
+			: base(key, count, placeholderKey1, placeholder1)
+		{
+		}
+
+		/// <summary>
+		/// Initialises a new instance of the TCExtension class.
+		/// </summary>
+		/// <param name="key">Text key to translate.</param>
+		/// <param name="placeholderKey1">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder1">The value binding to replace the placeholder when templating.</param>
+		/// <param name="placeholderKey2">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder2">The value binding to replace the placeholder when templating.</param>
+		public TCExtension(string key, string placeholderKey1, Binding placeholder1, string placeholderKey2, Binding placeholder2)
+			: base(key, placeholderKey1, placeholder1, placeholderKey2, placeholder2)
+		{
+		}
+
+		/// <summary>
+		/// Initialises a new instance of the TCExtension class.
+		/// </summary>
+		/// <param name="key">Text key to translate.</param>
+		/// <param name="count">Count value to consider when selecting the text value.</param>
+		/// <param name="placeholderKey1">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder1">The value binding to replace the placeholder when templating.</param>
+		/// <param name="placeholderKey2">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder2">The value binding to replace the placeholder when templating.</param>
+		public TCExtension(string key, int count, string placeholderKey1, Binding placeholder1, string placeholderKey2, Binding placeholder2)
+			: base(key, count, placeholderKey1, placeholder1, placeholderKey2, placeholder2)
+		{
+		}
+
+		/// <summary>
+		/// Initialises a new instance of the TCExtension class.
+		/// </summary>
+		/// <param name="key">Text key to translate.</param>
+		/// <param name="placeholderKey1">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder1">The value binding to replace the placeholder when templating.</param>
+		/// <param name="placeholderKey2">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder2">The value binding to replace the placeholder when templating.</param>
+		/// <param name="placeholderKey3">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder3">The value binding to replace the placeholder when templating.</param>
+		public TCExtension(string key, string placeholderKey1, Binding placeholder1, string placeholderKey2, Binding placeholder2, string placeholderKey3, Binding placeholder3)
+			: base(key, placeholderKey1, placeholder1, placeholderKey2, placeholder2, placeholderKey3, placeholder3)
+		{
+		}
+
+		/// <summary>
+		/// Initialises a new instance of the TCExtension class.
+		/// </summary>
+		/// <param name="key">Text key to translate.</param>
+		/// <param name="count">Count value to consider when selecting the text value.</param>
+		/// <param name="placeholderKey1">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder1">The value binding to replace the placeholder when templating.</param>
+		/// <param name="placeholderKey2">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder2">The value binding to replace the placeholder when templating.</param>
+		/// <param name="placeholderKey3">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder3">The value binding to replace the placeholder when templating.</param>
+		public TCExtension(string key, int count, string placeholderKey1, Binding placeholder1, string placeholderKey2, Binding placeholder2, string placeholderKey3, Binding placeholder3)
+			: base(key, count, placeholderKey1, placeholder1, placeholderKey2, placeholder2, placeholderKey3, placeholder3)
+		{
+		}
+
 		#endregion Constructors
 
 		#region Converter action
@@ -266,7 +663,25 @@ namespace Unclassified.TxLib
 		/// Provides the T method in specialised classes.
 		/// </summary>
 		/// <returns></returns>
-		protected override Func<string, int, string> GetTFunc()
+		protected override Func<string, int, string> GetTFuncCount()
+		{
+			return Tx.TC;
+		}
+
+		/// <summary>
+		/// Provides the T method in specialised classes.
+		/// </summary>
+		/// <returns></returns>
+		protected override Func<string, string[], string> GetTFuncPlaceholders()
+		{
+			return Tx.TC;
+		}
+
+		/// <summary>
+		/// Provides the T method in specialised classes.
+		/// </summary>
+		/// <returns></returns>
+		protected override Func<string, int, string[], string> GetTFuncCountAndPlaceholders()
 		{
 			return Tx.TC;
 		}
@@ -318,6 +733,54 @@ namespace Unclassified.TxLib
 		{
 		}
 
+		/// <summary>
+		/// Initialises a new instance of the UTCExtension class.
+		/// </summary>
+		public UTCExtension(string key, string placeholderKey1, Binding placeholder1)
+			: base(key, placeholderKey1, placeholder1)
+        {
+        }
+
+		/// <summary>
+		/// Initialises a new instance of the UTCExtension class.
+		/// </summary>
+		public UTCExtension(string key, int count, string placeholderKey1, Binding placeholder1)
+			: base(key, count, placeholderKey1, placeholder1)
+        {
+        }
+
+		/// <summary>
+		/// Initialises a new instance of the UTCExtension class.
+		/// </summary>
+		public UTCExtension(string key, string placeholderKey1, Binding placeholder1, string placeholderKey2, Binding placeholder2)
+			: base(key, placeholderKey1, placeholder1, placeholderKey2, placeholder2)
+		{
+		}
+
+		/// <summary>
+		/// Initialises a new instance of the UTCExtension class.
+		/// </summary>
+		public UTCExtension(string key, int count, string placeholderKey1, Binding placeholder1, string placeholderKey2, Binding placeholder2)
+			: base(key, count, placeholderKey1, placeholder1, placeholderKey2, placeholder2)
+		{
+		}
+
+		/// <summary>
+		/// Initialises a new instance of the UTCExtension class.
+		/// </summary>
+		public UTCExtension(string key, string placeholderKey1, Binding placeholder1, string placeholderKey2, Binding placeholder2, string placeholderKey3, Binding placeholder3)
+			: base(key, placeholderKey1, placeholder1, placeholderKey2, placeholder2, placeholderKey3, placeholder3)
+		{
+		}
+
+		/// <summary>
+		/// Initialises a new instance of the UTCExtension class.
+		/// </summary>
+		public UTCExtension(string key, int count, string placeholderKey1, Binding placeholder1, string placeholderKey2, Binding placeholder2, string placeholderKey3, Binding placeholder3)
+			: base(key, count, placeholderKey1, placeholder1, placeholderKey2, placeholder2, placeholderKey3, placeholder3)
+		{
+		}
+
 		#endregion Constructors
 
 		#region Converter action
@@ -326,7 +789,25 @@ namespace Unclassified.TxLib
 		/// Provides the T method in specialised classes.
 		/// </summary>
 		/// <returns></returns>
-		protected override Func<string, int, string> GetTFunc()
+		protected override Func<string, int, string> GetTFuncCount()
+		{
+			return Tx.UTC;
+		}
+
+		/// <summary>
+		/// Provides the T method in specialised classes.
+		/// </summary>
+		/// <returns></returns>
+		protected override Func<string, string[], string> GetTFuncPlaceholders()
+		{
+			return Tx.UTC;
+		}
+
+		/// <summary>
+		/// Provides the T method in specialised classes.
+		/// </summary>
+		/// <returns></returns>
+		protected override Func<string, int, string[], string> GetTFuncCountAndPlaceholders()
 		{
 			return Tx.UTC;
 		}
@@ -378,6 +859,87 @@ namespace Unclassified.TxLib
 		{
 		}
 
+		/// <summary>
+		/// Initialises a new instance of the QTExtension class.
+		/// </summary>
+		/// <param name="key">Text key to translate.</param>
+		/// <param name="placeholderKey1">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder1">The value binding to replace the placeholder when templating.</param>
+		public QTExtension(string key, string placeholderKey1, Binding placeholder1)
+			: base(key, placeholderKey1, placeholder1)
+		{
+		}
+
+		/// <summary>
+		/// Initialises a new instance of the QTExtension class.
+		/// </summary>
+		/// <param name="key">Text key to translate.</param>
+		/// <param name="count">Count value to consider when selecting the text value.</param>
+		/// <param name="placeholderKey1">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder1">The value binding to replace the placeholder when templating.</param>
+		public QTExtension(string key, int count, string placeholderKey1, Binding placeholder1)
+			: base(key, count, placeholderKey1, placeholder1)
+        {
+        }
+
+		/// <summary>
+		/// Initialises a new instance of the QTExtension class.
+		/// </summary>
+		/// <param name="key">Text key to translate.</param>
+		/// <param name="placeholderKey1">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder1">The value binding to replace the placeholder when templating.</param>
+		/// <param name="placeholderKey2">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder2">The value binding to replace the placeholder when templating.</param>
+		public QTExtension(string key, string placeholderKey1, Binding placeholder1, string placeholderKey2, Binding placeholder2)
+			: base(key, placeholderKey1, placeholder1, placeholderKey2, placeholder2)
+		{
+		}
+
+		/// <summary>
+		/// Initialises a new instance of the QTExtension class.
+		/// </summary>
+		/// <param name="key">Text key to translate.</param>
+		/// <param name="count">Count value to consider when selecting the text value.</param>
+		/// <param name="placeholderKey1">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder1">The value binding to replace the placeholder when templating.</param>
+		/// <param name="placeholderKey2">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder2">The value binding to replace the placeholder when templating.</param>
+		public QTExtension(string key, int count, string placeholderKey1, Binding placeholder1, string placeholderKey2, Binding placeholder2)
+			: base(key, count, placeholderKey1, placeholder1, placeholderKey2, placeholder2)
+		{
+		}
+
+		/// <summary>
+		/// Initialises a new instance of the QTExtension class.
+		/// </summary>
+		/// <param name="key">Text key to translate.</param>
+		/// <param name="placeholderKey1">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder1">The value binding to replace the placeholder when templating.</param>
+		/// <param name="placeholderKey2">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder2">The value binding to replace the placeholder when templating.</param>
+		/// <param name="placeholderKey3">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder3">The value binding to replace the placeholder when templating.</param>
+		public QTExtension(string key, string placeholderKey1, Binding placeholder1, string placeholderKey2, Binding placeholder2, string placeholderKey3, Binding placeholder3)
+			: base(key, placeholderKey1, placeholder1, placeholderKey2, placeholder2, placeholderKey3, placeholder3)
+		{
+		}
+
+		/// <summary>
+		/// Initialises a new instance of the QTExtension class.
+		/// </summary>
+		/// <param name="key">Text key to translate.</param>
+		/// <param name="count">Count value to consider when selecting the text value.</param>
+		/// <param name="placeholderKey1">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder1">The value binding to replace the placeholder when templating.</param>
+		/// <param name="placeholderKey2">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder2">The value binding to replace the placeholder when templating.</param>
+		/// <param name="placeholderKey3">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder3">The value binding to replace the placeholder when templating.</param>
+		public QTExtension(string key, int count, string placeholderKey1, Binding placeholder1, string placeholderKey2, Binding placeholder2, string placeholderKey3, Binding placeholder3)
+			: base(key, count, placeholderKey1, placeholder1, placeholderKey2, placeholder2, placeholderKey3, placeholder3)
+		{
+		}
+
 		#endregion Constructors
 
 		#region Converter action
@@ -386,7 +948,25 @@ namespace Unclassified.TxLib
 		/// Provides the T method in specialised classes.
 		/// </summary>
 		/// <returns></returns>
-		protected override Func<string, int, string> GetTFunc()
+		protected override Func<string, int, string> GetTFuncCount()
+		{
+			return Tx.QT;
+		}
+
+		/// <summary>
+		/// Provides the T method in specialised classes.
+		/// </summary>
+		/// <returns></returns>
+		protected override Func<string, string[], string> GetTFuncPlaceholders()
+		{
+			return Tx.QT;
+		}
+
+		/// <summary>
+		/// Provides the T method in specialised classes.
+		/// </summary>
+		/// <returns></returns>
+		protected override Func<string, int, string[], string> GetTFuncCountAndPlaceholders()
 		{
 			return Tx.QT;
 		}
@@ -438,6 +1018,87 @@ namespace Unclassified.TxLib
 		{
 		}
 
+		/// <summary>
+		/// Initialises a new instance of the QTCExtension class.
+		/// </summary>
+		/// <param name="key">Text key to translate.</param>
+		/// <param name="placeholderKey1">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder1">The value binding to replace the placeholder when templating.</param>
+		public QTCExtension(string key, string placeholderKey1, Binding placeholder1)
+			: base(key, placeholderKey1, placeholder1)
+		{
+		}
+
+		/// <summary>
+		/// Initialises a new instance of the QTCExtension class.
+		/// </summary>
+		/// <param name="key">Text key to translate.</param>
+		/// <param name="count">Count value to consider when selecting the text value.</param>
+		/// <param name="placeholderKey1">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder1">The value binding to replace the placeholder when templating.</param>
+		public QTCExtension(string key, int count, string placeholderKey1, Binding placeholder1)
+			: base(key, count, placeholderKey1, placeholder1)
+		{
+		}
+
+		/// <summary>
+		/// Initialises a new instance of the QTCExtension class.
+		/// </summary>
+		/// <param name="key">Text key to translate.</param>
+		/// <param name="placeholderKey1">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder1">The value binding to replace the placeholder when templating.</param>
+		/// <param name="placeholderKey2">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder2">The value binding to replace the placeholder when templating.</param>
+		public QTCExtension(string key, string placeholderKey1, Binding placeholder1, string placeholderKey2, Binding placeholder2)
+			: base(key, placeholderKey1, placeholder1, placeholderKey2, placeholder2)
+		{
+		}
+
+		/// <summary>
+		/// Initialises a new instance of the QTCExtension class.
+		/// </summary>
+		/// <param name="key">Text key to translate.</param>
+		/// <param name="count">Count value to consider when selecting the text value.</param>
+		/// <param name="placeholderKey1">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder1">The value binding to replace the placeholder when templating.</param>
+		/// <param name="placeholderKey2">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder2">The value binding to replace the placeholder when templating.</param>
+		public QTCExtension(string key, int count, string placeholderKey1, Binding placeholder1, string placeholderKey2, Binding placeholder2)
+			: base(key, count, placeholderKey1, placeholder1, placeholderKey2, placeholder2)
+		{
+		}
+
+		/// <summary>
+		/// Initialises a new instance of the QTCExtension class.
+		/// </summary>
+		/// <param name="key">Text key to translate.</param>
+		/// <param name="placeholderKey1">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder1">The value binding to replace the placeholder when templating.</param>
+		/// <param name="placeholderKey2">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder2">The value binding to replace the placeholder when templating.</param>
+		/// <param name="placeholderKey3">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder3">The value binding to replace the placeholder when templating.</param>
+		public QTCExtension(string key, string placeholderKey1, Binding placeholder1, string placeholderKey2, Binding placeholder2, string placeholderKey3, Binding placeholder3)
+			: base(key, placeholderKey1, placeholder1, placeholderKey2, placeholder2, placeholderKey3, placeholder3)
+		{
+		}
+
+		/// <summary>
+		/// Initialises a new instance of the QTCExtension class.
+		/// </summary>
+		/// <param name="key">Text key to translate.</param>
+		/// <param name="count">Count value to consider when selecting the text value.</param>
+		/// <param name="placeholderKey1">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder1">The value binding to replace the placeholder when templating.</param>
+		/// <param name="placeholderKey2">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder2">The value binding to replace the placeholder when templating.</param>
+		/// <param name="placeholderKey3">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder3">The value binding to replace the placeholder when templating.</param>
+		public QTCExtension(string key, int count, string placeholderKey1, Binding placeholder1, string placeholderKey2, Binding placeholder2, string placeholderKey3, Binding placeholder3)
+			: base(key, count, placeholderKey1, placeholder1, placeholderKey2, placeholder2, placeholderKey3, placeholder3)
+		{
+		}
+
 		#endregion Constructors
 
 		#region Converter action
@@ -446,7 +1107,25 @@ namespace Unclassified.TxLib
 		/// Provides the T method in specialised classes.
 		/// </summary>
 		/// <returns></returns>
-		protected override Func<string, int, string> GetTFunc()
+		protected override Func<string, int, string> GetTFuncCount()
+		{
+			return Tx.QTC;
+		}
+
+		/// <summary>
+		/// Provides the T method in specialised classes.
+		/// </summary>
+		/// <returns></returns>
+		protected override Func<string, string[], string> GetTFuncPlaceholders()
+		{
+			return Tx.QTC;
+		}
+
+		/// <summary>
+		/// Provides the T method in specialised classes.
+		/// </summary>
+		/// <returns></returns>
+		protected override Func<string, int, string[], string> GetTFuncCountAndPlaceholders()
 		{
 			return Tx.QTC;
 		}
@@ -498,6 +1177,87 @@ namespace Unclassified.TxLib
 		{
 		}
 
+		/// <summary>
+		/// Initialises a new instance of the QUTExtension class.
+		/// </summary>
+		/// <param name="key">Text key to translate.</param>
+		/// <param name="placeholderKey1">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder1">The value binding to replace the placeholder when templating.</param>
+		public QUTExtension(string key, string placeholderKey1, Binding placeholder1)
+			: base(key, placeholderKey1, placeholder1)
+		{
+		}
+
+		/// <summary>
+		/// Initialises a new instance of the QUTExtension class.
+		/// </summary>
+		/// <param name="key">Text key to translate.</param>
+		/// <param name="count">Count value to consider when selecting the text value.</param>
+		/// <param name="placeholderKey1">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder1">The value binding to replace the placeholder when templating.</param>
+		public QUTExtension(string key, int count, string placeholderKey1, Binding placeholder1)
+			: base(key, count, placeholderKey1, placeholder1)
+		{
+		}
+
+		/// <summary>
+		/// Initialises a new instance of the QUTExtension class.
+		/// </summary>
+		/// <param name="key">Text key to translate.</param>
+		/// <param name="placeholderKey1">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder1">The value binding to replace the placeholder when templating.</param>
+		/// <param name="placeholderKey2">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder2">The value binding to replace the placeholder when templating.</param>
+		public QUTExtension(string key, string placeholderKey1, Binding placeholder1, string placeholderKey2, Binding placeholder2)
+			: base(key, placeholderKey1, placeholder1, placeholderKey2, placeholder2)
+		{
+		}
+
+		/// <summary>
+		/// Initialises a new instance of the QUTExtension class.
+		/// </summary>
+		/// <param name="key">Text key to translate.</param>
+		/// <param name="count">Count value to consider when selecting the text value.</param>
+		/// <param name="placeholderKey1">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder1">The value binding to replace the placeholder when templating.</param>
+		/// <param name="placeholderKey2">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder2">The value binding to replace the placeholder when templating.</param>
+		public QUTExtension(string key, int count, string placeholderKey1, Binding placeholder1, string placeholderKey2, Binding placeholder2)
+			: base(key, count, placeholderKey1, placeholder1, placeholderKey2, placeholder2)
+		{
+		}
+
+		/// <summary>
+		/// Initialises a new instance of the QUTExtension class.
+		/// </summary>
+		/// <param name="key">Text key to translate.</param>
+		/// <param name="placeholderKey1">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder1">The value binding to replace the placeholder when templating.</param>
+		/// <param name="placeholderKey2">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder2">The value binding to replace the placeholder when templating.</param>
+		/// <param name="placeholderKey3">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder3">The value binding to replace the placeholder when templating.</param>
+		public QUTExtension(string key, string placeholderKey1, Binding placeholder1, string placeholderKey2, Binding placeholder2, string placeholderKey3, Binding placeholder3)
+			: base(key, placeholderKey1, placeholder1, placeholderKey2, placeholder2, placeholderKey3, placeholder3)
+		{
+		}
+
+		/// <summary>
+		/// Initialises a new instance of the QUTExtension class.
+		/// </summary>
+		/// <param name="key">Text key to translate.</param>
+		/// <param name="count">Count value to consider when selecting the text value.</param>
+		/// <param name="placeholderKey1">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder1">The value binding to replace the placeholder when templating.</param>
+		/// <param name="placeholderKey2">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder2">The value binding to replace the placeholder when templating.</param>
+		/// <param name="placeholderKey3">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder3">The value binding to replace the placeholder when templating.</param>
+		public QUTExtension(string key, int count, string placeholderKey1, Binding placeholder1, string placeholderKey2, Binding placeholder2, string placeholderKey3, Binding placeholder3)
+			: base(key, count, placeholderKey1, placeholder1, placeholderKey2, placeholder2, placeholderKey3, placeholder3)
+		{
+		}
+
 		#endregion Constructors
 
 		#region Converter action
@@ -506,7 +1266,25 @@ namespace Unclassified.TxLib
 		/// Provides the T method in specialised classes.
 		/// </summary>
 		/// <returns></returns>
-		protected override Func<string, int, string> GetTFunc()
+		protected override Func<string, int, string> GetTFuncCount()
+		{
+			return Tx.QUT;
+		}
+
+		/// <summary>
+		/// Provides the T method in specialised classes.
+		/// </summary>
+		/// <returns></returns>
+		protected override Func<string, string[], string> GetTFuncPlaceholders()
+		{
+			return Tx.QUT;
+		}
+
+		/// <summary>
+		/// Provides the T method in specialised classes.
+		/// </summary>
+		/// <returns></returns>
+		protected override Func<string, int, string[], string> GetTFuncCountAndPlaceholders()
 		{
 			return Tx.QUT;
 		}
@@ -558,6 +1336,87 @@ namespace Unclassified.TxLib
 		{
 		}
 
+		/// <summary>
+		/// Initialises a new instance of the QUTCExtension class.
+		/// </summary>
+		/// <param name="key">Text key to translate.</param>
+		/// <param name="placeholderKey1">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder1">The value binding to replace the placeholder when templating.</param>
+		public QUTCExtension(string key, string placeholderKey1, Binding placeholder1)
+			: base(key, placeholderKey1, placeholder1)
+		{
+		}
+
+		/// <summary>
+		/// Initialises a new instance of the QUTCExtension class.
+		/// </summary>
+		/// <param name="key">Text key to translate.</param>
+		/// <param name="count">Count value to consider when selecting the text value.</param>
+		/// <param name="placeholderKey1">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder1">The value binding to replace the placeholder when templating.</param>
+		public QUTCExtension(string key, int count, string placeholderKey1, Binding placeholder1)
+			: base(key, count, placeholderKey1, placeholder1)
+		{
+		}
+
+		/// <summary>
+		/// Initialises a new instance of the QUTCExtension class.
+		/// </summary>
+		/// <param name="key">Text key to translate.</param>
+		/// <param name="placeholderKey1">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder1">The value binding to replace the placeholder when templating.</param>
+		/// <param name="placeholderKey2">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder2">The value binding to replace the placeholder when templating.</param>
+		public QUTCExtension(string key, string placeholderKey1, Binding placeholder1, string placeholderKey2, Binding placeholder2)
+			: base(key, placeholderKey1, placeholder1, placeholderKey2, placeholder2)
+		{
+		}
+
+		/// <summary>
+		/// Initialises a new instance of the QUTCExtension class.
+		/// </summary>
+		/// <param name="key">Text key to translate.</param>
+		/// <param name="count">Count value to consider when selecting the text value.</param>
+		/// <param name="placeholderKey1">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder1">The value binding to replace the placeholder when templating.</param>
+		/// <param name="placeholderKey2">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder2">The value binding to replace the placeholder when templating.</param>
+		public QUTCExtension(string key, int count, string placeholderKey1, Binding placeholder1, string placeholderKey2, Binding placeholder2)
+			: base(key, count, placeholderKey1, placeholder1, placeholderKey2, placeholder2)
+		{
+		}
+
+		/// <summary>
+		/// Initialises a new instance of the QUTCExtension class.
+		/// </summary>
+		/// <param name="key">Text key to translate.</param>
+		/// <param name="placeholderKey1">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder1">The value binding to replace the placeholder when templating.</param>
+		/// <param name="placeholderKey2">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder2">The value binding to replace the placeholder when templating.</param>
+		/// <param name="placeholderKey3">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder3">The value binding to replace the placeholder when templating.</param>
+		public QUTCExtension(string key, string placeholderKey1, Binding placeholder1, string placeholderKey2, Binding placeholder2, string placeholderKey3, Binding placeholder3)
+			: base(key, placeholderKey1, placeholder1, placeholderKey2, placeholder2, placeholderKey3, placeholder3)
+		{
+		}
+
+		/// <summary>
+		/// Initialises a new instance of the QUTCExtension class.
+		/// </summary>
+		/// <param name="key">Text key to translate.</param>
+		/// <param name="count">Count value to consider when selecting the text value.</param>
+		/// <param name="placeholderKey1">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder1">The value binding to replace the placeholder when templating.</param>
+		/// <param name="placeholderKey2">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder2">The value binding to replace the placeholder when templating.</param>
+		/// <param name="placeholderKey3">The name of the placeholder in the localization resource.</param>
+		/// <param name="placeholder3">The value binding to replace the placeholder when templating.</param>
+		public QUTCExtension(string key, int count, string placeholderKey1, Binding placeholder1, string placeholderKey2, Binding placeholder2, string placeholderKey3, Binding placeholder3)
+			: base(key, count, placeholderKey1, placeholder1, placeholderKey2, placeholder2, placeholderKey3, placeholder3)
+		{
+		}
+
 		#endregion Constructors
 
 		#region Converter action
@@ -566,7 +1425,25 @@ namespace Unclassified.TxLib
 		/// Provides the T method in specialised classes.
 		/// </summary>
 		/// <returns></returns>
-		protected override Func<string, int, string> GetTFunc()
+		protected override Func<string, int, string> GetTFuncCount()
+		{
+			return Tx.QUTC;
+		}
+
+		/// <summary>
+		/// Provides the T method in specialised classes.
+		/// </summary>
+		/// <returns></returns>
+		protected override Func<string, string[], string> GetTFuncPlaceholders()
+		{
+			return Tx.QUTC;
+		}
+
+		/// <summary>
+		/// Provides the T method in specialised classes.
+		/// </summary>
+		/// <returns></returns>
+		protected override Func<string, int, string[], string> GetTFuncCountAndPlaceholders()
 		{
 			return Tx.QUTC;
 		}
@@ -972,7 +1849,8 @@ namespace Unclassified.TxLib
 
 		private string key;
 		private int count;
-		private Func<string, int, string> tFunc;
+		private string[] placeholder_keys;
+		private object tFunc;
 		private string defaultValue;
 
 		#endregion Private fields
@@ -1008,6 +1886,39 @@ namespace Unclassified.TxLib
 			this.defaultValue = defaultValue;
 		}
 
+		/// <summary>
+		/// Initialises a new instance of the TConverter class.
+		/// </summary>
+		/// <param name="tFunc"></param>
+		/// <param name="key">Text key to translate.</param>
+		/// <param name="placeholder_keys">Placeholders key and values data.</param>
+		/// <param name="defaultValue">Default text to display at design time.</param>
+		public TConverter(Func<string, string[], string> tFunc, string key, string[] placeholder_keys, string defaultValue)
+        {
+			this.tFunc = tFunc;
+			this.key = key;
+			this.placeholder_keys = placeholder_keys;
+			this.count = -1;
+			this.defaultValue = defaultValue;
+        }
+
+		/// <summary>
+		/// Initialises a new instance of the TConverter class.
+		/// </summary>
+		/// <param name="tFunc"></param>
+		/// <param name="key">Text key to translate.</param>
+		/// <param name="count">Count value to consider when selecting the text value.</param>
+		/// <param name="placeholder_keys">Placeholders keys.</param>
+		/// <param name="defaultValue">Default text to display at design time.</param>
+		public TConverter(Func<string, int, string[], string> tFunc, string key, int count, string[] placeholder_keys, string defaultValue)
+        {
+			this.tFunc = tFunc;
+			this.key = key;
+			this.placeholder_keys = placeholder_keys;
+			this.count = count;
+			this.defaultValue = defaultValue;
+        }
+
 		#endregion Constructors
 
 		#region IValueConverter members
@@ -1023,7 +1934,15 @@ namespace Unclassified.TxLib
 			// value is the Dummy binding, don't use it
 
 			// Now translate the text and return the result.
-			return tFunc(key, count);
+			if (tFunc is Func<string, int, string> tFunc_str_int)
+				return tFunc_str_int(key, count);
+			if (tFunc is Func<string, string[], string> tFunc_str_strArr)
+				return tFunc_str_strArr(key, placeholder_keys);
+			if (tFunc is Func<string, int, string[], string> tFunc_str_int_strArr)
+				return tFunc_str_int_strArr(key, count, placeholder_keys);
+
+			// shouldn't reach here
+			return defaultValue ?? key;
 		}
 
 		public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
@@ -1044,25 +1963,53 @@ namespace Unclassified.TxLib
 			}
 
 			// values[0] is the Dummy binding, don't use it
-
-			// Read the count value from binding number two.
-			int count = -1;
-			if (values.Length > 1)
-			{
-				if (values[1] != DependencyProperty.UnsetValue)
-				{
-					count = System.Convert.ToInt32(values[1]);
-				}
-			}
+			values = values.Skip(1).ToArray();
 
 			// Now translate the text and return the result.
-			return tFunc(key, count);
+			if (tFunc is Func<string, int, string> tFunc_string_int)
+            {
+				// read the count value
+				if (values[0] != DependencyProperty.UnsetValue)
+					count = System.Convert.ToInt32(values[0]);
+				return tFunc_string_int(key, count);
+			}
+			if (tFunc is Func<string, string[], string> tFunc_string_stringArr)
+            {
+				// read the bound parameter values
+				values = values.Where(v => v != DependencyProperty.UnsetValue).ToArray();
+				var args = JoinKeyValuePairs(placeholder_keys, values).ToArray();
+				return tFunc_string_stringArr(key, args);
+            }
+			if (tFunc is Func<string, int, string[], string> tFunc_string_int_stringArr)
+            {
+				// read the count value
+				if (values[0] != DependencyProperty.UnsetValue)
+					count = System.Convert.ToInt32(values[0]);
+
+				// read the bound parameter values
+				values = values.Where(v => v != DependencyProperty.UnsetValue).ToArray();
+				var args = JoinKeyValuePairs(placeholder_keys, values).ToArray();
+				return tFunc_string_int_stringArr(key, count, args);
+			}
+			return null;
 		}
 
 		public object[] ConvertBack(object value, Type[] targetTypes, object parameter, System.Globalization.CultureInfo culture)
 		{
 			return new object[0];
 		}
+
+		private IEnumerable<string> JoinKeyValuePairs(IEnumerable<string> keys, IEnumerable<object> values)
+        {
+			var iter_keys = keys.GetEnumerator();
+			var iter_values = values.GetEnumerator();
+
+			while (iter_keys.MoveNext() && iter_values.MoveNext())
+            {
+				yield return iter_keys.Current;
+				yield return iter_values.Current as string;
+            }
+        }
 
 		#endregion IMultiValueConverter members
 	}

--- a/WpfDemo/MainWindow.xaml
+++ b/WpfDemo/MainWindow.xaml
@@ -16,6 +16,7 @@
 			<RowDefinition Height="Auto"/>
 			<RowDefinition Height="Auto"/>
 			<RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
 			<RowDefinition Height="*"/>
 		</Grid.RowDefinitions>
 
@@ -49,5 +50,11 @@
 				</Style>
 			</TextBlock.Style>
 		</TextBlock>
+
+        <TextBlock Grid.Row="9" HorizontalAlignment="Center"
+                   Text="{Tx:T Key=test.params.xaml,
+								PlaceholderKey1=extra, PlaceholderBinding1={Binding Path=Extra},
+								PlaceholderKey2=amp, PlaceholderBinding2={Binding Path=Amp}}">
+        </TextBlock>
 	</Grid>
 </Window>

--- a/WpfDemo/MainWindow.xaml.cs
+++ b/WpfDemo/MainWindow.xaml.cs
@@ -7,6 +7,9 @@ namespace WpfDemo
 {
 	public partial class MainWindow : Window
 	{
+		public string Extra => "too many";
+		public string Amp => "no context whatsoever";
+
 		public MainWindow()
 		{
 			// Setup logging

--- a/WpfDemo/lang/languages.txd
+++ b/WpfDemo/lang/languages.txd
@@ -1,6 +1,130 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- TxTranslation dictionary file. Use TxEditor to edit this file. http://unclassified.software/txtranslation -->
 <translation xml:space="preserve">
+	<culture name="de">
+		<text key="errors">Fehler</text>
+		<text key="months">Monate</text>
+		<text key="months" count="1">Monat</text>
+		<text key="n months">{#} Monate</text>
+		<text key="n months" count="1">ein Monat</text>
+		<text key="Tx:date.day">d.</text>
+		<text key="Tx:date.month day">dd.MM.</text>
+		<text key="Tx:date.month day abbr">d. MMM.</text>
+		<text key="Tx:date.year month">MM/yyyy</text>
+		<text key="Tx:date.year month abbr">MMM. yyyy</text>
+		<text key="Tx:date.year month day abbr">d. MMM. yyyy</text>
+		<text key="Tx:date.year month day long">d. MMMM yyyy</text>
+		<text key="Tx:number.group separator"> </text>
+		<text key="Tx:number.group separator threshold">10000</text>
+		<text key="Tx:number.negative">−</text>
+		<text key="Tx:number.ordinal">{#}.</text>
+		<text key="Tx:number.unit separator"> </text>
+		<text key="Tx:quote begin">„</text>
+		<text key="Tx:quote end">“</text>
+		<text key="Tx:quote nested begin">‚</text>
+		<text key="Tx:quote nested end">‘</text>
+		<text key="Tx:time.hour">H "Uhr"</text>
+		<text key="Tx:time.never">nie</text>
+		<text key="Tx:time.now">jetzt</text>
+		<text key="Tx:time.relative">in {interval}</text>
+		<text key="Tx:time.relative.days">{#} Tagen</text>
+		<text key="Tx:time.relative.days" count="1">{#} Tag</text>
+		<text key="Tx:time.relative.hours">{#} Stunden</text>
+		<text key="Tx:time.relative.hours" count="1">{#} Stunde</text>
+		<text key="Tx:time.relative.minutes">{#} Minuten</text>
+		<text key="Tx:time.relative.minutes" count="1">{#} Minute</text>
+		<text key="Tx:time.relative.months">{#} Monaten</text>
+		<text key="Tx:time.relative.months" count="1">{#} Monat</text>
+		<text key="Tx:time.relative.seconds">{#} Sekunden</text>
+		<text key="Tx:time.relative.seconds" count="1">{#} Sekunde</text>
+		<text key="Tx:time.relative.years">{#} Jahren</text>
+		<text key="Tx:time.relative.years" count="1">{#} Jahr</text>
+		<text key="Tx:time.relative neg">vor {interval}</text>
+		<text key="Tx:time.relative neg.days">{#} Tagen</text>
+		<text key="Tx:time.relative neg.days" count="1">{#} Tag</text>
+		<text key="Tx:time.relative neg.hours">{#} Stunden</text>
+		<text key="Tx:time.relative neg.hours" count="1">{#} Stunde</text>
+		<text key="Tx:time.relative neg.minutes">{#} Minuten</text>
+		<text key="Tx:time.relative neg.minutes" count="1">{#} Minute</text>
+		<text key="Tx:time.relative neg.months">{#} Monaten</text>
+		<text key="Tx:time.relative neg.months" count="1">{#} Monat</text>
+		<text key="Tx:time.relative neg.seconds">{#} Sekunden</text>
+		<text key="Tx:time.relative neg.seconds" count="1">{#} Sekunde</text>
+		<text key="Tx:time.relative neg.years">{#} Jahren</text>
+		<text key="Tx:time.relative neg.years" count="1">{#} Jahr</text>
+		<text key="Tx:time.relative separator"> </text>
+		<text key="Tx:time.relative span">für {interval}</text>
+		<text key="Tx:time.relative span.days">{#} Tage</text>
+		<text key="Tx:time.relative span.days" count="1">{#} Tag</text>
+		<text key="Tx:time.relative span.hours">{#} Stunden</text>
+		<text key="Tx:time.relative span.hours" count="1">{#} Stunde</text>
+		<text key="Tx:time.relative span.minutes">{#} Minuten</text>
+		<text key="Tx:time.relative span.minutes" count="1">{#} Minute</text>
+		<text key="Tx:time.relative span.months">{#} Monate</text>
+		<text key="Tx:time.relative span.months" count="1">{#} Monat</text>
+		<text key="Tx:time.relative span.seconds">{#} Sekunden</text>
+		<text key="Tx:time.relative span.seconds" count="1">{#} Sekunde</text>
+		<text key="Tx:time.relative span.years">{#} Jahre</text>
+		<text key="Tx:time.relative span.years" count="1">{#} Jahr</text>
+		<text key="Tx:time.relative span neg">seit {interval}</text>
+		<text key="Tx:time.relative span neg.days">{#} Tagen</text>
+		<text key="Tx:time.relative span neg.days" count="1">{#} Tag</text>
+		<text key="Tx:time.relative span neg.hours">{#} Stunden</text>
+		<text key="Tx:time.relative span neg.hours" count="1">{#} Stunde</text>
+		<text key="Tx:time.relative span neg.minutes">{#} Minuten</text>
+		<text key="Tx:time.relative span neg.minutes" count="1">{#} Minute</text>
+		<text key="Tx:time.relative span neg.months">{#} Monaten</text>
+		<text key="Tx:time.relative span neg.months" count="1">{#} Monat</text>
+		<text key="Tx:time.relative span neg.seconds">{#} Sekunden</text>
+		<text key="Tx:time.relative span neg.seconds" count="1">{#} Sekunde</text>
+		<text key="Tx:time.relative span neg.years">{#} Jahren</text>
+		<text key="Tx:time.relative span neg.years" count="1">{#} Jahr</text>
+		<text key="Tx:time.span">{interval} später</text>
+		<text key="Tx:time.span.days">{#} Tage</text>
+		<text key="Tx:time.span.days" count="1">{#} Tag</text>
+		<text key="Tx:time.span.hours">{#} Stunden</text>
+		<text key="Tx:time.span.hours" count="1">{#} Stunde</text>
+		<text key="Tx:time.span.minutes">{#} Minuten</text>
+		<text key="Tx:time.span.minutes" count="1">{#} Minute</text>
+		<text key="Tx:time.span.months">{#} Monate</text>
+		<text key="Tx:time.span.months" count="1">{#} Monat</text>
+		<text key="Tx:time.span.seconds">{#} Sekunden</text>
+		<text key="Tx:time.span.seconds" count="1">{#} Sekunde</text>
+		<text key="Tx:time.span.years">{#} Jahre</text>
+		<text key="Tx:time.span.years" count="1">{#} Jahr</text>
+		<text key="Tx:time.span neg">{interval} davor</text>
+		<text key="Tx:time.span neg.days">{#} Tage</text>
+		<text key="Tx:time.span neg.days" count="1">{#} Tag</text>
+		<text key="Tx:time.span neg.hours">{#} Stunden</text>
+		<text key="Tx:time.span neg.hours" count="1">{#} Stunde</text>
+		<text key="Tx:time.span neg.minutes">{#} Minuten</text>
+		<text key="Tx:time.span neg.minutes" count="1">{#} Minute</text>
+		<text key="Tx:time.span neg.months">{#} Monate</text>
+		<text key="Tx:time.span neg.months" count="1">{#} Monat</text>
+		<text key="Tx:time.span neg.seconds">{#} Sekunden</text>
+		<text key="Tx:time.span neg.seconds" count="1">{#} Sekunde</text>
+		<text key="Tx:time.span neg.years">{#} Jahre</text>
+		<text key="Tx:time.span neg.years" count="1">{#} Jahr</text>
+		<text key="warnings">Warnungen</text>
+		<text key="warnings" count="1">Warnung</text>
+	</culture>
+	<culture name="de-AT">
+		<text key="Tx:number.group separator threshold">1</text>
+	</culture>
+	<culture name="de-CH">
+		<text key="Tx:quote begin">«</text>
+		<text key="Tx:quote end">»</text>
+		<text key="Tx:quote nested begin">‹</text>
+		<text key="Tx:quote nested end">›</text>
+	</culture>
 	<culture name="en" primary="true">
+		<text key="errors">errors</text>
+		<text key="errors" count="1">error</text>
+		<text key="errors and warnings">There are {err} {=errors#err} and {warn} {=warnings#warn}.</text>
+		<text key="months">months</text>
+		<text key="months" count="1">month</text>
+		<text key="n months">{#} {=months#}</text>
+		<text key="test.params.xaml">show {extra} text with {amp}</text>
 		<text key="Tx:date.month day">d/M</text>
 		<text key="Tx:date.month day abbr">d MMM</text>
 		<text key="Tx:date.month day long">d MMMM</text>
@@ -106,14 +230,14 @@
 		<text key="Tx:time.span neg.seconds" count="1">{#} second</text>
 		<text key="Tx:time.span neg.years">{#} years</text>
 		<text key="Tx:time.span neg.years" count="1">{#} year</text>
-		<text key="errors">errors</text>
-		<text key="errors" count="1">error</text>
-		<text key="errors and warnings">There are {err} {=errors#err} and {warn} {=warnings#warn}.</text>
-		<text key="months">months</text>
-		<text key="months" count="1">month</text>
-		<text key="n months">{#} {=months#}</text>
 		<text key="warnings">warnings</text>
 		<text key="warnings" count="1">warning</text>
+	</culture>
+	<culture name="en-AU">
+		<text key="Tx:time.am">am</text>
+		<text key="Tx:time.hour">h tt</text>
+		<text key="Tx:time.hour minute second ms">h:mm:ss.fff tt</text>
+		<text key="Tx:time.pm">pm</text>
 	</culture>
 	<culture name="en-US">
 		<text key="Tx:date.month day">M/d</text>
@@ -125,128 +249,6 @@
 		<text key="Tx:date.year month day long">MMMM d, yyyy</text>
 		<text key="Tx:time.hour">h tt</text>
 		<text key="Tx:time.hour minute second ms">h:mm:ss.fff tt</text>
-	</culture>
-	<culture name="en-AU">
-		<text key="Tx:time.am">am</text>
-		<text key="Tx:time.hour">h tt</text>
-		<text key="Tx:time.hour minute second ms">h:mm:ss.fff tt</text>
-		<text key="Tx:time.pm">pm</text>
-	</culture>
-	<culture name="de">
-		<text key="Tx:date.day">d.</text>
-		<text key="Tx:date.month day">dd.MM.</text>
-		<text key="Tx:date.month day abbr">d. MMM.</text>
-		<text key="Tx:date.year month">MM/yyyy</text>
-		<text key="Tx:date.year month abbr">MMM. yyyy</text>
-		<text key="Tx:date.year month day abbr">d. MMM. yyyy</text>
-		<text key="Tx:date.year month day long">d. MMMM yyyy</text>
-		<text key="Tx:number.group separator"> </text>
-		<text key="Tx:number.group separator threshold">10000</text>
-		<text key="Tx:number.negative">−</text>
-		<text key="Tx:number.ordinal">{#}.</text>
-		<text key="Tx:number.unit separator"> </text>
-		<text key="Tx:quote begin">„</text>
-		<text key="Tx:quote end">“</text>
-		<text key="Tx:quote nested begin">‚</text>
-		<text key="Tx:quote nested end">‘</text>
-		<text key="Tx:time.hour">H "Uhr"</text>
-		<text key="Tx:time.never">nie</text>
-		<text key="Tx:time.now">jetzt</text>
-		<text key="Tx:time.relative">in {interval}</text>
-		<text key="Tx:time.relative.days">{#} Tagen</text>
-		<text key="Tx:time.relative.days" count="1">{#} Tag</text>
-		<text key="Tx:time.relative.hours">{#} Stunden</text>
-		<text key="Tx:time.relative.hours" count="1">{#} Stunde</text>
-		<text key="Tx:time.relative.minutes">{#} Minuten</text>
-		<text key="Tx:time.relative.minutes" count="1">{#} Minute</text>
-		<text key="Tx:time.relative.months">{#} Monaten</text>
-		<text key="Tx:time.relative.months" count="1">{#} Monat</text>
-		<text key="Tx:time.relative.seconds">{#} Sekunden</text>
-		<text key="Tx:time.relative.seconds" count="1">{#} Sekunde</text>
-		<text key="Tx:time.relative.years">{#} Jahren</text>
-		<text key="Tx:time.relative.years" count="1">{#} Jahr</text>
-		<text key="Tx:time.relative neg">vor {interval}</text>
-		<text key="Tx:time.relative neg.days">{#} Tagen</text>
-		<text key="Tx:time.relative neg.days" count="1">{#} Tag</text>
-		<text key="Tx:time.relative neg.hours">{#} Stunden</text>
-		<text key="Tx:time.relative neg.hours" count="1">{#} Stunde</text>
-		<text key="Tx:time.relative neg.minutes">{#} Minuten</text>
-		<text key="Tx:time.relative neg.minutes" count="1">{#} Minute</text>
-		<text key="Tx:time.relative neg.months">{#} Monaten</text>
-		<text key="Tx:time.relative neg.months" count="1">{#} Monat</text>
-		<text key="Tx:time.relative neg.seconds">{#} Sekunden</text>
-		<text key="Tx:time.relative neg.seconds" count="1">{#} Sekunde</text>
-		<text key="Tx:time.relative neg.years">{#} Jahren</text>
-		<text key="Tx:time.relative neg.years" count="1">{#} Jahr</text>
-		<text key="Tx:time.relative separator"> </text>
-		<text key="Tx:time.relative span">für {interval}</text>
-		<text key="Tx:time.relative span.days">{#} Tage</text>
-		<text key="Tx:time.relative span.days" count="1">{#} Tag</text>
-		<text key="Tx:time.relative span.hours">{#} Stunden</text>
-		<text key="Tx:time.relative span.hours" count="1">{#} Stunde</text>
-		<text key="Tx:time.relative span.minutes">{#} Minuten</text>
-		<text key="Tx:time.relative span.minutes" count="1">{#} Minute</text>
-		<text key="Tx:time.relative span.months">{#} Monate</text>
-		<text key="Tx:time.relative span.months" count="1">{#} Monat</text>
-		<text key="Tx:time.relative span.seconds">{#} Sekunden</text>
-		<text key="Tx:time.relative span.seconds" count="1">{#} Sekunde</text>
-		<text key="Tx:time.relative span.years">{#} Jahre</text>
-		<text key="Tx:time.relative span.years" count="1">{#} Jahr</text>
-		<text key="Tx:time.relative span neg">seit {interval}</text>
-		<text key="Tx:time.relative span neg.days">{#} Tagen</text>
-		<text key="Tx:time.relative span neg.days" count="1">{#} Tag</text>
-		<text key="Tx:time.relative span neg.hours">{#} Stunden</text>
-		<text key="Tx:time.relative span neg.hours" count="1">{#} Stunde</text>
-		<text key="Tx:time.relative span neg.minutes">{#} Minuten</text>
-		<text key="Tx:time.relative span neg.minutes" count="1">{#} Minute</text>
-		<text key="Tx:time.relative span neg.months">{#} Monaten</text>
-		<text key="Tx:time.relative span neg.months" count="1">{#} Monat</text>
-		<text key="Tx:time.relative span neg.seconds">{#} Sekunden</text>
-		<text key="Tx:time.relative span neg.seconds" count="1">{#} Sekunde</text>
-		<text key="Tx:time.relative span neg.years">{#} Jahren</text>
-		<text key="Tx:time.relative span neg.years" count="1">{#} Jahr</text>
-		<text key="Tx:time.span">{interval} später</text>
-		<text key="Tx:time.span.days">{#} Tage</text>
-		<text key="Tx:time.span.days" count="1">{#} Tag</text>
-		<text key="Tx:time.span.hours">{#} Stunden</text>
-		<text key="Tx:time.span.hours" count="1">{#} Stunde</text>
-		<text key="Tx:time.span.minutes">{#} Minuten</text>
-		<text key="Tx:time.span.minutes" count="1">{#} Minute</text>
-		<text key="Tx:time.span.months">{#} Monate</text>
-		<text key="Tx:time.span.months" count="1">{#} Monat</text>
-		<text key="Tx:time.span.seconds">{#} Sekunden</text>
-		<text key="Tx:time.span.seconds" count="1">{#} Sekunde</text>
-		<text key="Tx:time.span.years">{#} Jahre</text>
-		<text key="Tx:time.span.years" count="1">{#} Jahr</text>
-		<text key="Tx:time.span neg">{interval} davor</text>
-		<text key="Tx:time.span neg.days">{#} Tage</text>
-		<text key="Tx:time.span neg.days" count="1">{#} Tag</text>
-		<text key="Tx:time.span neg.hours">{#} Stunden</text>
-		<text key="Tx:time.span neg.hours" count="1">{#} Stunde</text>
-		<text key="Tx:time.span neg.minutes">{#} Minuten</text>
-		<text key="Tx:time.span neg.minutes" count="1">{#} Minute</text>
-		<text key="Tx:time.span neg.months">{#} Monate</text>
-		<text key="Tx:time.span neg.months" count="1">{#} Monat</text>
-		<text key="Tx:time.span neg.seconds">{#} Sekunden</text>
-		<text key="Tx:time.span neg.seconds" count="1">{#} Sekunde</text>
-		<text key="Tx:time.span neg.years">{#} Jahre</text>
-		<text key="Tx:time.span neg.years" count="1">{#} Jahr</text>
-		<text key="errors">Fehler</text>
-		<text key="months">Monate</text>
-		<text key="months" count="1">Monat</text>
-		<text key="n months">{#} Monate</text>
-		<text key="n months" count="1">ein Monat</text>
-		<text key="warnings">Warnungen</text>
-		<text key="warnings" count="1">Warnung</text>
-	</culture>
-	<culture name="de-AT">
-		<text key="Tx:number.group separator threshold">1</text>
-	</culture>
-	<culture name="de-CH">
-		<text key="Tx:quote begin">«</text>
-		<text key="Tx:quote end">»</text>
-		<text key="Tx:quote nested begin">‹</text>
-		<text key="Tx:quote nested end">›</text>
 	</culture>
 	<culture name="es">
 		<text key="Tx:number.group separator"> </text>
@@ -265,6 +267,8 @@
 		<text key="Tx:quote nested end">›</text>
 	</culture>
 	<culture name="fr">
+		<text key="months">mois</text>
+		<text key="n months">{#} mois</text>
 		<text key="Tx:byte unit">o</text>
 		<text key="Tx:colon"> :</text>
 		<text key="Tx:date.dow with date">{dow} {date}</text>
@@ -287,8 +291,6 @@
 		<text key="Tx:quote nested end">”</text>
 		<text key="Tx:time.hour">H "h"</text>
 		<text key="Tx:time.hour minute">H "h" mm</text>
-		<text key="months">mois</text>
-		<text key="n months">{#} mois</text>
 	</culture>
 	<culture name="it">
 		<text key="Tx:date.dow with date">{dow} {date}</text>


### PR DESCRIPTION
Problem: Localization text template paramaters were not supported with XAML.

I have introduced support for up to 3 pairs of template parameter names and values.

```xaml
<TextBlock 
       Text="{Tx:T Key=test.params.xaml,
			PlaceholderKey1=extra, PlaceholderBinding1={Binding Path=Extra},
			PlaceholderKey2=amp, PlaceholderBinding2={Binding Path=Amp}}">
</TextBlock>
```

Which would localize the template:

> show {extra} text with {amp}

I don't think any functionality is broken by this addition. Maybe the example .txd file should not be included in the merge.